### PR TITLE
Fix the bug of not able to statrt influxDB in K8S

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -205,7 +205,7 @@ data:
       bind-socket = "/var/run/influxdb.sock"
     [[graphite]]
       enabled = false
-      bind-address = 2003
+      bind-address = ":2003"
       database = "graphite"
       retention-policy = "autogen"
       protocol = "tcp"


### PR DESCRIPTION
This bug will return confused information:
`run: parse config: toml: cannot load TOML value of type int64 into a Go string`